### PR TITLE
Frame cropped area

### DIFF
--- a/autocrop.py
+++ b/autocrop.py
@@ -164,6 +164,16 @@ def parse_commandline_options(defaults):
             )
         )
     parser.add_argument(
+        '-t', '--filetype',
+        nargs='?',
+        type=str,
+        choices=['png', 'jpg'],
+        default=defaults.filetype,
+        help=(
+            'Filetype of the cropped images (default: png)'
+            )
+        )
+    parser.add_argument(
         'target',
         nargs='?',
         default=os.getcwd(),
@@ -189,7 +199,8 @@ def get_config_params():
         "resolution": 300,
         "shrink": 0,
         "contrast": 5,
-        "precision": 50
+        "precision": 50,
+        "filetype": "png"
     }
     return Config(os.path.join(AUTOCROP_DIR, 'config.json'), defaults=default_params)
 
@@ -243,7 +254,7 @@ def autocrop_file(options, image, background):
         options.shrink
     )
     for crop in multipart_image:
-        file_name = '%s-%s.png' % (date_name, next(letters))
+        file_name = f'{date_name}-{next(letters)}.{options.filetype}'
         full_path = os.path.join(target, file_name)
         print('Saving %s' % full_path)
         crop.save(full_path)

--- a/autocrop.py
+++ b/autocrop.py
@@ -224,6 +224,7 @@ def autocrop_file(options, image, background):
     target = os.path.abspath(options.target)
     if not os.path.exists(target):
         os.makedirs(target)
+
     multipart_image = MultiPartImage(
         image,
         background,
@@ -238,6 +239,9 @@ def autocrop_file(options, image, background):
         full_path = os.path.join(target, file_name)
         print('Saving %s' % full_path)
         crop.save(full_path)
+
+    full_path_original_image = os.path.join(target, 'tmp-full-scan.jpg')
+    multipart_image.image.save(full_path_original_image, quality=90)
 
 
 def main(options):

--- a/autocrop.py
+++ b/autocrop.py
@@ -155,6 +155,17 @@ def parse_commandline_options():
         help='Do not auto-correct the rotation of the photos after cropping.'
         )
     parser.add_argument(
+        '-k', '--shrink',
+        nargs='?',
+        type=int,
+        default=3,
+        help=(
+            'Number of pixels to shrink the area to be cropped. Avoid a possible small '
+            'white border at the cost of a slightly smaller image. Only relevant if '
+            'the image is deskewed (default: 3)'
+            )
+        )
+    parser.add_argument(
         'target',
         nargs='?',
         default=os.getcwd(),
@@ -223,7 +234,8 @@ def autocrop_file(options, background):
         options.resolution,
         options.precision,
         options.deskew,
-        options.contrast
+        options.contrast,
+        options.shrink
     )
     for crop in multipart_image:
         file_name = '%s-%s.png' % (date_name, next(letters))

--- a/autocrop.py
+++ b/autocrop.py
@@ -134,9 +134,9 @@ def parse_commandline_options():
         )
     parser.add_argument(
         '-f', '--filename',
-        nargs='?',
+        nargs='*',
         default='',
-        help='Do not scan. Instead, load the image from the given file.'
+        help='Do not scan. Instead, load the image from the given file(s).'
         )
     parser.add_argument(
         '-c', '--contrast',
@@ -214,17 +214,13 @@ def scan_and_save_background_data(options, background, bg_records, bg_file):
     os.rename(temp_bg_file_name, bg_file)
 
 
-def autocrop_file(options, background):
+def autocrop_file(options, image, background):
     # Autocrop a file.
     date_name = time.strftime(
         '%Y-%m-%d-%H%M%S',
         time.localtime(time.time())
     )
     letters = iter('abcdefghijklmnopqrstuvwxyz')
-    if options.filename:
-        image = Image.open(options.filename)
-    else:
-        image = scan(options.resolution, options.scanner)
     target = os.path.abspath(options.target)
     if not os.path.exists(target):
         os.makedirs(target)
@@ -268,7 +264,14 @@ def main(options):
         scan_and_save_background_data(options, background, bg_records, bg_file)
     
     else:
-        autocrop_file(options, background)
+        if options.filename:
+            for filename in options.filename:
+                print(f'autocrop {filename}')
+                image = Image.open(filename)
+                autocrop_file(options, image, background)
+        else:
+            image = scan(options.resolution, options.scanner)
+            autocrop_file(options, image, background)
 
 
 if __name__ == '__main__':

--- a/autocrop.py
+++ b/autocrop.py
@@ -17,12 +17,10 @@ import subprocess
 import sys
 import tempfile
 import time
-
+from simple_config import Config
 from PIL import Image
-
 from autocrop.image import MultiPartImage
 from autocrop.background import Background
-
 
 if os.name == 'posix':
     APP_CONF_DIR = os.environ.get(
@@ -86,7 +84,7 @@ def get_scanner_base_name(device):
     return name
 
 
-def parse_commandline_options():
+def parse_commandline_options(defaults):
     parser = argparse.ArgumentParser(
         description='A utility to crop multiple photos out of a scanned image.'
         )
@@ -107,7 +105,7 @@ def parse_commandline_options():
         '-r', '--resolution',
         nargs='?',
         type=int,
-        default=300,
+        default=defaults.resolution,
         help=(
             'The resolution, in dots per inch, to use while '
             'scanning (default: 300).'
@@ -117,7 +115,7 @@ def parse_commandline_options():
         '-p', '--precision',
         nargs='?',
         type=int,
-        default=50,
+        default=defaults.precision,
         help=(
             'The precision to use while cropping. Higher is better '
             'but slower (default: 50).'
@@ -143,7 +141,7 @@ def parse_commandline_options():
         nargs='?',
         type=int,
         choices=list(range(1, 11)),
-        default=5,
+        default=defaults.contrast,
         help=(
             'The amount of contrast (1-10) between background '
             'and foreground. (default: 5).'
@@ -158,7 +156,7 @@ def parse_commandline_options():
         '-k', '--shrink',
         nargs='?',
         type=int,
-        default=3,
+        default=defaults.shrink,
         help=(
             'Number of pixels to shrink the area to be cropped. Avoid a possible small '
             'white border at the cost of a slightly smaller image. Only relevant if '
@@ -184,6 +182,16 @@ def list_all_scanners():
     # List all scanners.
     for name, device in detect_scanners():
         print(name)
+
+
+def get_config_params():
+    default_params = {
+        "resolution": 300,
+        "shrink": 0,
+        "contrast": 5,
+        "precision": 50
+    }
+    return Config(os.path.join(AUTOCROP_DIR, 'config.json'), defaults=default_params)
 
 
 def scan_and_save_background_data(options, background, bg_records, bg_file):
@@ -244,7 +252,8 @@ def autocrop_file(options, image, background):
     multipart_image.image.save(full_path_original_image, quality=90)
 
 
-def main(options):
+def main():
+    options = parse_commandline_options(get_config_params())
     bg_file = os.path.join(AUTOCROP_DIR, 'backgrounds.json')
     try:
         with open(bg_file, 'r') as f:
@@ -279,4 +288,4 @@ def main(options):
 
 
 if __name__ == '__main__':
-    main(parse_commandline_options())
+    main()

--- a/autocrop/image.py
+++ b/autocrop/image.py
@@ -2,6 +2,8 @@
 
 from .sampler import PixelSampler
 from .skew import SkewedImage
+from PIL import Image, ImageDraw
+from numpy import mean
 
 
 class MultiPartImage(object):
@@ -27,9 +29,16 @@ class MultiPartImage(object):
             image = self.image.crop(
                 (section.left, section.top, section.right, section.bottom)
                 )
+
             if self.deskew:
                 skew = SkewedImage(image, self.background, self.contrast, self.shrink)
-                image = skew.correct()
+                image, margins, angle = skew.correct()
+            else:
+                margins = (0, 0, 0, 0)
+                angle = 0
+
+            self.frame_cropped_area(section, margins, angle)
+
             yield image
     
     def __len__(self):
@@ -68,6 +77,19 @@ class MultiPartImage(object):
         
         # Filter out sections smaller than 1 square inch before returning.
         return [s for s in sections if s > self.dpi ** 2]
+
+    def frame_cropped_area(self, section, margins, angle):
+        rectangle = Image.new("RGBA", self.image.size, (0, 0, 0, 0))
+
+        center = (mean([section.left, section.right]), mean([section.top, section.bottom]))
+        drawer = ImageDraw.Draw(rectangle)
+        xy = [section.left + margins[0], section.top + margins[1],
+              section.right - margins[0], section.top + margins[3]]
+
+        drawer.rectangle(xy, outline="yellow", width=8)
+        drawer.rectangle(xy, outline="blue", width=4)
+        rectangle_rotated = rectangle.rotate(-angle, center=center)
+        self.image = Image.alpha_composite(self.image.convert("RGBA"), rectangle_rotated).convert("RGB")
 
 
 class ImageSection(object):

--- a/autocrop/image.py
+++ b/autocrop/image.py
@@ -10,13 +10,14 @@ class MultiPartImage(object):
     This is used, for example, to detect and access multiple photos that were
     scanned simultaneously in a flat-bed scanner. """
     def __init__(self, image, background, dpi, precision=50,
-            deskew=True, contrast=15):
+            deskew=True, contrast=15, shrink=3):
         self.contrast = contrast
         self.image = image
         self.dpi = dpi
         self.width, self.height = image.size
         self.precision = precision
         self.deskew = deskew
+        self.shrink = shrink
         self.samples = PixelSampler(image, dpi, precision)
         self.background = background
         self.sections = self._find_sections()
@@ -27,7 +28,7 @@ class MultiPartImage(object):
                 (section.left, section.top, section.right, section.bottom)
                 )
             if self.deskew:
-                skew = SkewedImage(image, self.background, self.contrast)
+                skew = SkewedImage(image, self.background, self.contrast, self.shrink)
                 image = skew.correct()
             yield image
     

--- a/autocrop/skew.py
+++ b/autocrop/skew.py
@@ -28,12 +28,14 @@ class SkewedImage(object):
         margins, angles = list(
             zip(*[self._get_margin(side) for side in self.sides])
             )
-        rotated_img = self.image.rotate(degrees(numpy.median(angles)), BICUBIC)
+
+        angle = degrees(numpy.median(angles))
+        rotated_img = self.image.rotate(angle, BICUBIC)
 
         # margins: (left, upper, right, lower)
         shrunk_margins = tuple(v + self.shrink for v in margins[0:2]) + tuple(v - self.shrink for v in margins[2:4])
 
-        return rotated_img.crop(shrunk_margins)
+        return rotated_img.crop(shrunk_margins), shrunk_margins, angle
     
     def _get_margin(self, side):
         """Find the distance and angle of the margin on a particular side.

--- a/autocrop/skew.py
+++ b/autocrop/skew.py
@@ -10,11 +10,12 @@ from .sampler import PixelSampler
 
 class SkewedImage(object):
     
-    def __init__(self, image, background, contrast=10):
+    def __init__(self, image, background, contrast=10, shrink=0):
         self.image = image
         self.width, self.height = image.size
         self.background = background
         self.contrast = contrast
+        self.shrink = shrink
         sampler = PixelSampler(image, dpi=1, precision=1)
         self.sides = (
             Left(sampler),
@@ -28,7 +29,11 @@ class SkewedImage(object):
             zip(*[self._get_margin(side) for side in self.sides])
             )
         rotated_img = self.image.rotate(degrees(numpy.median(angles)), BICUBIC)
-        return rotated_img.crop(margins)
+
+        # margins: (left, upper, right, lower)
+        shrunk_margins = tuple(v + self.shrink for v in margins[0:2]) + tuple(v - self.shrink for v in margins[2:4])
+
+        return rotated_img.crop(shrunk_margins)
     
     def _get_margin(self, side):
         """Find the distance and angle of the margin on a particular side.

--- a/tests/test_skew.py
+++ b/tests/test_skew.py
@@ -17,7 +17,7 @@ class TestSkewedImage(unittest.TestCase):
         shrink = 5  # shrink image on each side by 5 pixels to avoid any background
         test_image_path = os.path.join(IMAGE_PATH, '6-degrees-skewed.jpg')
         skewed = SkewedImage(Image.open(test_image_path), Background(), shrink=shrink)
-        deskewed = skewed.correct()
+        deskewed, margins, angle = skewed.correct()
         width, height = deskewed.size
         
         # The true measurements of the image

--- a/tests/test_skew.py
+++ b/tests/test_skew.py
@@ -14,17 +14,16 @@ from tests.const import IMAGE_PATH
 class TestSkewedImage(unittest.TestCase):
     
     def test_skew(self):
+        shrink = 5  # shrink image on each side by 5 pixels to avoid any background
         test_image_path = os.path.join(IMAGE_PATH, '6-degrees-skewed.jpg')
-        skewed = SkewedImage(Image.open(test_image_path), Background())
-        angles = [skewed._get_margin(side)[1] for side in skewed.sides]
-        angle = degrees(np.median(angles))
+        skewed = SkewedImage(Image.open(test_image_path), Background(), shrink=shrink)
         deskewed = skewed.correct()
         width, height = deskewed.size
         
         # The true measurements of the image
         correct_angle = 6.0
-        correct_width = 604
-        correct_height = 604
+        correct_width = 604 - 2*shrink
+        correct_height = 604 - 2*shrink
         
         self.assertAlmostEqual(angle, correct_angle, delta=0.1)
         self.assertAlmostEqual(correct_width, width, delta=2)


### PR DESCRIPTION
- Parameter --framed-crop creates an additional image which allows for visual quality control of the autocropping by adding a frame around the cropped area. Also works with skewed images

- Parameter --filename accepts multiple files. All files are processed in one go

- Parameter --shrink cuts away a small border around the cropped images to ensure that no background is left after cropping

- Parameter --filetype allows to specify the filetype such as png or jpg

- Default parameters are read from ~/.config/autocrop/config.json

- Factor out functions from main()

- Adapt unittest for API change and also test the new shrinking

